### PR TITLE
Added msg2xml as a Function import to __init__.py

### DIFF
--- a/takproto/__init__.py
+++ b/takproto/__init__.py
@@ -32,6 +32,7 @@
 
 from .functions import (  # NOQA
     xml2proto,
+    msg2xml,
     parse_proto,
     parse_mesh,
     parse_stream,


### PR DESCRIPTION
Exposing msg2xml as a function import in order to convert Parsed TakProto messages to XML